### PR TITLE
Remove newline characters from refs

### DIFF
--- a/javalink/ref.py
+++ b/javalink/ref.py
@@ -114,7 +114,7 @@ class JavarefRole(EnvAccessor):
         return self.app.env
 
     def find_ref(self, reftext):
-        reftext = reftext.strip()
+        reftext = reftext.strip().replace('\r\n', '').replace('\n', '').replace('\r', '')
 
         # TODO add additional validation (see SeeTagImpl.java)
         where, _, what = reftext.partition('#')


### PR DESCRIPTION
Having hard line breaks in the sphinx document might introduce new line
characters in the ref line and matching will fail. Since newlines are
not allowed in the signature, we can safely remove the newline
characters.
